### PR TITLE
Only setup index_map if not NULL

### DIFF
--- a/device/lib/ckks_common.c
+++ b/device/lib/ckks_common.c
@@ -70,13 +70,15 @@ void ckks_calc_index_map(const Parms *parms, uint16_t *index_map)
 void ckks_setup(size_t degree, size_t nprimes, uint16_t *index_map, Parms *parms)
 {
     set_parms_ckks(degree, nprimes, parms);
+    if (index_map) {
 #ifdef SE_INDEX_MAP_PERSIST
-    ckks_calc_index_map(parms, index_map);
+        ckks_calc_index_map(parms, index_map);
 #elif defined(SE_INDEX_MAP_LOAD_PERSIST)
-    load_index_map(parms, index_map);
+        load_index_map(parms, index_map);
 #elif defined(SE_INDEX_MAP_LOAD_PERSIST_SYM_LOAD_ASYM)
-    if (!parms->is_asymmetric) load_index_map(parms, index_map);
+        if (!parms->is_asymmetric) load_index_map(parms, index_map);
 #endif
+    }
 }
 
 void ckks_setup_custom(size_t degree, size_t nprimes, const ZZ *modulus_vals, const ZZ *ratios,


### PR DESCRIPTION
Hi,

I got a segfault while trying to run the benchmarks locally. Seems that e.g. in [bench_index_map.c:34](https://github.com/microsoft/SEAL-Embedded/blob/0913fa9afe1f2bdc0d995f853a685aceea6d3cd0/device/bench/bench_index_map.c#L34), [`ckks_setup()`](https://github.com/microsoft/SEAL-Embedded/blob/0913fa9afe1f2bdc0d995f853a685aceea6d3cd0/device/lib/ckks_common.c#L70) is called with `index_map` as `NULL`. And `index_map` is always dereferenced on [line 55](https://github.com/microsoft/SEAL-Embedded/blob/0913fa9afe1f2bdc0d995f853a685aceea6d3cd0/device/lib/ckks_common.c#L55).

This pull request ensures that `ckks_setup()` only operates on `index_map` if it is not `NULL`, though I am not sure if that really is the intended way forward.